### PR TITLE
Adding missing import to UIImage+ImageWithColor.h

### DIFF
--- a/src/ios/TouchDraw/UIImage+ImageWithColor.h
+++ b/src/ios/TouchDraw/UIImage+ImageWithColor.h
@@ -1,4 +1,4 @@
-
+#import <UIKit/UIKit.h>
 
 @interface UIImage (ImageWithColor)
 + (UIImage *)imageWithColor:(UIColor *)color andSize:(CGRect)size;


### PR DESCRIPTION
Adding missing `#import <UIKit/UIKit.h>` to UIImage+ImageWithColor.h